### PR TITLE
Recursive flag missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Any fixes or improvements are always welcome!!
 2. Copy collector script
     ``` bash
     cd esp32servermon
-    cp metrics-collector /opt/
+    cp -r metrics-collector /opt/
     ```
 3. Install python requirments
     ``` python


### PR DESCRIPTION
When copying a directory you need to use -r to make sure all its content is transferred over